### PR TITLE
Added the flag -Wno-variadic-macros to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RE2C?=re2c
 
 # Flags
 
-CXXFLAGS=-O2 -ggdb -Wall -ansi -Ibuild/ -Imodules/ -I. -fno-rtti -pedantic -fno-exceptions
+CXXFLAGS=-O2 -ggdb -Wall -ansi -Wno-variadic-macros -Ibuild/ -Imodules/ -I. -fno-rtti -pedantic -fno-exceptions
 CXXFLAGS3=-ggdb -O2
 # Linker
 LFLAGS=-O2 -fno-rtti -fno-exceptions


### PR DESCRIPTION
Added the flag -Wno-variadic-macros to Makefile. Now no more warnings about the use of variadic macros.
