### PR TITLE
Moving argument type checking to the visitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ RE2C?=re2c
 
 # Flags
 
-CXXFLAGS=-O2 -ggdb -Wall -ansi -Wno-variadic-macros -I. -fno-rtti -pedantic -fno-exceptions
+CXXFLAGS=-O2 -ggdb -Wall -ansi -I. -fno-rtti -pedantic -fno-exceptions
 CXXFLAGS3=-ggdb -O2
 # Linker
 LFLAGS=-O2 -fno-rtti -fno-exceptions
@@ -80,7 +80,7 @@ $(BUILDDIR)cstring.o: $(COMPDIR)cstring.cc
 $(BUILDDIR)compiler.o: $(COMPDIR)compiler.cc $(BUILDDIR)driver.o $(BUILDDIR)int.o $(BUILDDIR)double.o $(BUILDDIR)pkgmanager.o $(BUILDDIR)cgvisitor.o
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)compiler.o $(COMPDIR)compiler.cc
 
-$(BUILDDIR)cgvisitor.o: $(COMPDIR)cgvisitor.cc
+$(BUILDDIR)cgvisitor.o: $(COMPDIR)cgvisitor.cc $(BUILDDIR)typeutils.o
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)cgvisitor.o $(COMPDIR)cgvisitor.cc
 
 $(BUILDDIR)vm.o: $(VMDIR)vm.cc
@@ -96,26 +96,26 @@ $(BUILDDIR)pkgmanager.o: $(COMPDIR)pkgmanager.cc $(BUILDDIR)std_pkg.o
 $(BUILDDIR)typeutils.o: $(TYPEDIR)typeutils.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)typeutils.o $(TYPEDIR)typeutils.cc
 
-$(BUILDDIR)double.o: $(TYPEDIR)double.cc $(TYPEDIR)typeutils.cc
+$(BUILDDIR)double.o: $(TYPEDIR)double.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)double.o $(TYPEDIR)double.cc
 
-$(BUILDDIR)int.o: $(TYPEDIR)int.cc $(TYPEDIR)typeutils.cc
+$(BUILDDIR)int.o: $(TYPEDIR)int.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)int.o $(TYPEDIR)int.cc
 
-$(BUILDDIR)string_type.o: $(TYPEDIR)string_type.cc $(TYPEDIR)typeutils.cc
+$(BUILDDIR)string_type.o: $(TYPEDIR)string_type.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)string_type.o $(TYPEDIR)string_type.cc
 
 # Standard package
 $(BUILDDIR)std_pkg.o: $(MODDIR)std/io/io.cc $(MODDIR)std/math/math.cc $(MODDIR)std/file/file.cc $(MODDIR)std/std_pkg.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)std_pkg.o $(MODDIR)std/std_pkg.cc
 
-$(BUILDDIR)io.o: $(BUILDDIR)pkgmanager.o $(MODDIR)std/io/io.cc $(TYPEDIR)typeutils.cc
+$(BUILDDIR)io.o: $(BUILDDIR)pkgmanager.o $(MODDIR)std/io/io.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)io.o $(MODDIR)std/io/io.cc
 
-$(BUILDDIR)math.o: $(BUILDDIR)pkgmanager.o $(MODDIR)std/math/math.cc $(TYPEDIR)typeutils.cc
+$(BUILDDIR)math.o: $(BUILDDIR)pkgmanager.o $(MODDIR)std/math/math.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)math.o $(MODDIR)std/math/math.cc
 
-$(BUILDDIR)filestream.o: $(MODDIR)std/file/filestream.cc $(TYPEDIR)typeutils.cc
+$(BUILDDIR)filestream.o: $(MODDIR)std/file/filestream.cc
 	$(CXX) $(CXXFLAGS) -c -o $(BUILDDIR)filestream.o $(MODDIR)std/file/filestream.cc
 
 $(BUILDDIR)file.o: $(BUILDDIR)pkgmanager.o $(BUILDDIR)filestream.o $(MODDIR)std/file/file.cc

--- a/compiler/method.h
+++ b/compiler/method.h
@@ -51,15 +51,9 @@ typedef void (CLEVER_FASTCALL *MethodPtr)(CLEVER_METHOD_ARGS);
 class Method {
 public:
 	enum MethodType { INTERNAL, USER };
-	
-	Method(std::string name, MethodPtr ptr)
-		: m_name(name), m_type(INTERNAL), m_args(NULL), m_is_initialized(false), m_rtype(NULL)
-	{
-		m_info.ptr = ptr; 
-	}
 
-	Method(std::string name, MethodPtr ptr, const Type* rtype)
-		: m_name(name), m_type(INTERNAL), m_args(NULL), m_is_initialized(false), m_rtype(rtype)
+	Method(std::string name, MethodPtr ptr, TypeVector* args, const Type* rtype)
+		: m_name(name), m_type(INTERNAL), m_args(args), m_rtype(rtype)
 	{
 		m_info.ptr = ptr; 
 	}
@@ -82,14 +76,8 @@ public:
 	long call() const throw() { return m_info.offset; }
 	
 	const TypeVector* getArgs() const throw() { return m_args; }
-	void setArgs(const TypeVector* const args) { m_args = args; m_is_initialized = true; }
 	
 	const Type* getReturn() const throw() { return m_rtype; } 
-	
-	/**
-	 * Checks if the m_args has been initialized
-	 */
-	bool isArgsInitialized() const { return m_is_initialized; }
 	
 private:
 	union {
@@ -105,11 +93,6 @@ private:
 	 * Check with isArgsInitialized() before using it.
 	 */
 	const TypeVector* m_args;
-	
-	/**
-	 * True if the m_args pointer is initialized
-	 */
-	bool m_is_initialized;
 	
 	/**
 	 * Method's return type

--- a/modules/std/file/filestream.cc
+++ b/modules/std/file/filestream.cc
@@ -26,6 +26,7 @@
 #include <fstream>
 #include "compiler/compiler.h"
 #include "compiler/cstring.h"
+#include "types/typeutils.h"
 #include "modules/std/file/filestream.h"
 
 namespace clever { namespace packages { namespace std { namespace file {
@@ -111,9 +112,14 @@ CLEVER_TYPE_METHOD(FileStream::read) {
 
 
 void FileStream::init() {
-	addMethod(new Method("toString", (MethodPtr)&FileStream::toString));
-	addMethod(new Method("open", (MethodPtr)&FileStream::open));
-	addMethod(new Method("read", (MethodPtr)&FileStream::read));
+	addMethod(new Method("toString", (MethodPtr)&FileStream::toString, 
+		makeArgs(NULL), CLEVER_TYPE("Void")));
+		
+	addMethod(new Method("open", (MethodPtr)&FileStream::open, 
+		makeArgs(CLEVER_TYPE("String"), NULL), CLEVER_TYPE("Void")));
+		
+	addMethod(new Method("read", (MethodPtr)&FileStream::read, 
+		makeArgs(CLEVER_TYPE("String"), NULL), CLEVER_TYPE("Void")));
 }
 
 DataValue* FileStream::allocateValue() const {

--- a/types/double.cc
+++ b/types/double.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <cmath>
 #include "compiler/cstring.h"
-#include "type.h"
-#include "double.h"
+#include "types/typeutils.h"
+#include "types/type.h"
+#include "types/double.h"
 
 namespace clever {
 
@@ -50,8 +51,11 @@ CLEVER_TYPE_METHOD(Double::sqrt) {
 }
 
 void Double::init() {
-	addMethod(new Method("tostring", (MethodPtr)&Double::toString, CLEVER_TYPE("String")));
-	addMethod(new Method("sqrt", (MethodPtr)&Double::sqrt, CLEVER_TYPE("Double")));
+	addMethod(new Method("toString", (MethodPtr)&Double::toString, 
+		makeArgs(NULL), CLEVER_TYPE("String")));
+		
+	addMethod(new Method("sqrt", (MethodPtr)&Double::sqrt, 
+		makeArgs(NULL), CLEVER_TYPE("Double")));
 }
 
 DataValue* Double::allocateValue() const {

--- a/types/int.cc
+++ b/types/int.cc
@@ -25,8 +25,9 @@
 
 #include <iostream>
 #include "compiler/cstring.h"
-#include "type.h"
-#include "int.h"
+#include "types/typeutils.h"
+#include "types/type.h"
+#include "types/int.h"
 
 namespace clever {
 
@@ -40,7 +41,8 @@ CLEVER_TYPE_METHOD(Integer::toString) {
 }
 
 void Integer::init() {
-	addMethod(new Method("tostring", (MethodPtr)&Integer::toString, CLEVER_TYPE("String")));
+	addMethod(new Method("toString", (MethodPtr)&Integer::toString, 
+		makeArgs(NULL), CLEVER_TYPE("String")));
 }
 
 DataValue* Integer::allocateValue() const {

--- a/types/string_type.cc
+++ b/types/string_type.cc
@@ -39,7 +39,6 @@ namespace clever {
  * Replace part of the string and returns the new one.
  */
 CLEVER_TYPE_METHOD(String::replace) {
-	CLEVER_CHECK_ARGS("String::replace", CLEVER_TYPE("String"), CLEVER_TYPE("String"), NULL);
 	size_t needleLength, needlePos;
 	std::string newString = value->toString();
 
@@ -64,9 +63,7 @@ CLEVER_TYPE_METHOD(String::replace) {
  * String::substring(Int, Int)
  * Retrieves a substring from the original one.
  */
-CLEVER_TYPE_METHOD(String::substring) {
-	CLEVER_CHECK_ARGS("String::substring", CLEVER_TYPE("Int"), CLEVER_TYPE("Int"), NULL);
-	
+CLEVER_TYPE_METHOD(String::substring) {	
 	if (size_t(args->at(0)->getInteger()) >= value->toString().length()) {
 		std::cerr << "Out of range: " << args->at(0)->getInteger() 
 			<< " is after the end of the string." << std::endl;
@@ -83,8 +80,6 @@ CLEVER_TYPE_METHOD(String::substring) {
  * Converts the string to a double, if possible.
  */
 CLEVER_TYPE_METHOD(String::toDouble) {
-	CLEVER_CHECK_ARGS("String::toDouble", NULL);
-	
 	double floatValue;
 	std::stringstream stream(value->toString());
 
@@ -101,9 +96,7 @@ CLEVER_TYPE_METHOD(String::toDouble) {
  * String::toInteger()
  * Converts the string to an integer, if possible.
  */
-CLEVER_TYPE_METHOD(String::toInteger) {
-	CLEVER_CHECK_ARGS("String::toInteger", NULL);
-	
+CLEVER_TYPE_METHOD(String::toInteger) {	
 	int64_t integer;
 	std::stringstream stream(value->toString());
 
@@ -119,10 +112,17 @@ CLEVER_TYPE_METHOD(String::toInteger) {
 void String::init() {
 	const Type* const str_type = CLEVER_TYPE("String");
 
-	addMethod(new Method("replace", (MethodPtr)&String::replace, str_type));
-	addMethod(new Method("substring", (MethodPtr)&String::substring, str_type));
-	addMethod(new Method("toDouble", (MethodPtr)&String::toDouble, CLEVER_TYPE("Double")));
-	addMethod(new Method("toInteger", (MethodPtr)&String::toInteger, CLEVER_TYPE("Int")));
+	addMethod(new Method("replace", (MethodPtr)&String::replace, 
+		makeArgs(str_type, str_type, NULL), str_type));
+	
+	addMethod(new Method("substring", (MethodPtr)&String::substring, 
+		makeArgs(CLEVER_TYPE("Int"), CLEVER_TYPE("Int"), NULL), str_type));
+	
+	addMethod(new Method("toDouble", (MethodPtr)&String::toDouble, 
+		makeArgs(NULL), CLEVER_TYPE("Double")));
+		
+	addMethod(new Method("toInteger", (MethodPtr)&String::toInteger, 
+		makeArgs(NULL), CLEVER_TYPE("Int")));
 }
 
 DataValue* String::allocateValue() const {

--- a/types/typeutils.cc
+++ b/types/typeutils.cc
@@ -24,46 +24,34 @@
  */
 
 #include <cstdarg>
+#include <cassert>
 #include "types/typeutils.h"
 
 namespace clever {
 
-void addArgs(Method* method, ...)
+std::string argsError(const TypeVector* expected, const ValueVector* argv)
 {
-	using namespace std;
-	va_list li;
-	
-	TypeVector* tv = NULL;
-	
-	const Type* t1;
-	va_start(li, method);
-	
-	t1 = va_arg(li, const Type*);
-	
-	if (t1 != NULL) tv = new TypeVector();
-	
-	while (t1 != NULL) {
-		tv->push_back(t1);
-		t1 = va_arg(li, const Type*);
-	}
-	
-	method->setArgs(tv);
-	va_end(li);
-}
+	std::string error = "(";
+	int sz = 0;
 
-std::string argsError(const std::string& name, const TypeVector* expected, const ValueVector* args)
-{
-	std::string error = "No matching call for " + name + "(";
-	size_t size = args->size();
+	if (argv) sz = argv->size();
 	
-	for (size_t i = 0; i < size-1; ++i) {
-		error += args->at(i)->getTypePtr()->getName();
+	for (int i = 0; i < sz-1; ++i) {	
+		error += argv->at(i)->getTypePtr()->getName();
 		error += ", ";
 	}
 	
-	if (size > 0) {
-		error += args->at(size-1)->getTypePtr()->getName();
+	if (sz > 0) error += argv->at(sz-1)->getTypePtr()->getName();
+	
+	error += "). Expecting (";
+	
+	sz = expected ? expected->size() : 0;
+	for (int i = 0; i < sz-1; ++i) {
+		error += expected->at(i)->getName();
+		error += ", ";
 	}
+	
+	if (sz > 0) error += expected->at(sz-1)->getName();
 	
 	error += ")";
 	
@@ -92,6 +80,25 @@ bool checkArgs(const TypeVector* expected, const ValueVector* args) {
 	}
 	
 	return true;
+}
+
+TypeVector* makeArgs(const Type* type1, ...) {
+	va_list li;
+	TypeVector* tv = NULL;
+	const Type* t1 = type1;
+	
+	if (t1 != NULL) tv = new TypeVector();
+	
+	va_start(li, type1);
+	
+	while (t1 != NULL) {
+		tv->push_back(t1);
+		t1 = va_arg(li, const Type*);
+	}
+	
+	va_end(li);
+	
+	return tv;
 }
 
 } // clever

--- a/types/typeutils.h
+++ b/types/typeutils.h
@@ -33,26 +33,6 @@
 #include "compiler/compiler.h"
 
 namespace clever {
-
-/**
- * CLEVER_CHECK_ARGS("Class::methodName", CLEVER_TYPE("Type1"), CLEVER_TYPE("Type2"), …, CLEVER_TYPE("TypeN"), NULL) :
- * 	receives the method name string and the argument types **in order** and a NULL constant to mark the end.
- * 	Checks and conveniently initializes the methods arguments.
- *	Use ONLY inside a CLEVER_TYPE_METHOD definition.
- */
-#define CLEVER_CHECK_ARGS(name, ...) do { \
-	if (!clv_method_->isArgsInitialized()) { \
-		addArgs(clv_method_, __VA_ARGS__); \
-	}\
-	if (!checkArgs(clv_method_->getArgs(), args)) \
-		Compiler::error(argsError(name, clv_method_->getArgs(), args)); \
-} while (false)
-
-/**
- * addArgs(method, type1, type2, ...), adds the argument types in the method object
- */
-void addArgs(Method*, ...);
-
 /**
  * Checks if the Value*s contained in the ValueVector have the same 
  * type as the types in the TypeVector
@@ -60,9 +40,14 @@ void addArgs(Method*, ...);
 bool checkArgs(const TypeVector*, const ValueVector*);
 
 /**
- * Prints an error related to wrong arguments and exits the program
+ * Prints an error related to wrong arguments
  */
-std::string argsError(const std::string&, const TypeVector*, const ValueVector*);
+std::string argsError(const TypeVector*, const ValueVector*);
+
+/**
+ * Makes a TypeVector* with the args of a function/method
+ */
+TypeVector* makeArgs(const Type*, ...);
 
 } // clever
 


### PR DESCRIPTION
Now the argument type checking is done on the visitor.
The helpers for checking can be used by including "types/typeutils.h"
