### PR TITLE
Adding slice method to Array base type

### DIFF
--- a/tests/array_009.test
+++ b/tests/array_009.test
@@ -1,0 +1,35 @@
+Testing Array's slice method
+==CODE==
+import std.io;
+
+Array<String> x;
+x.push('Printing');
+x.push('with');
+x.push('array');
+x.push('slice');
+x.push('method.');
+
+println(x.slice(0, 1).toString());
+println(x.slice(1, 2).toString());
+println(x.slice(2, 0).toString());
+println(x.slice(2, -1).toString());
+println(x.slice(-1, 1).toString());
+println(x.slice(-3, 0).toString());
+println(x.slice(10, 2).toString());
+
+Array<Int> y;
+y.push(1);
+y.push(2);
+y.push(3);
+y.push(4);
+
+println(y.slice(-3, -1).toString());
+==RESULT==
+\[Printing\]
+\[with, array\]
+\[array, slice, method.\]
+\[array, slice\]
+\[method.\]
+\[array, slice, method.\]
+Warning: Value of start param (10) is greater than Array size
+\[2, 3\]

--- a/types/array.cc
+++ b/types/array.cc
@@ -201,6 +201,56 @@ CLEVER_METHOD(Array::resize) {
 	}
 }
 
+
+CLEVER_METHOD(Array::slice) {
+	ValueVector* vec = CLEVER_THIS()->getVector();
+	size_t sz = vec->size();
+	
+	int64_t start = CLEVER_ARG(0)->getInteger();
+	int64_t length = CLEVER_ARG(1)->getInteger();
+	
+	int64_t r_start = 0;
+	int64_t r_end = 0;
+	
+	if (start < 0) {
+		r_start = sz + start;
+	}
+	else {
+		r_start = start;
+	}
+	
+	if (length == 0) {
+		r_end = sz;
+	}
+	else if (length < 0) {
+		r_end = sz + length;
+	}
+	else {
+		r_end = r_start + length;
+	}
+	
+	ValueVector* n_vec = new ValueVector;
+	
+	if (r_start >= (int64_t) sz) {
+		Compiler::warningf("Value of start param (%l) is greater than Array size", start);
+	}
+	else if (r_end > (int64_t) sz) {
+		Compiler::warningf("Wrong value of length param (%l)", length);
+	}
+	else if (r_start > r_end) {
+		Compiler::warningf("The length param value (%l) must be valid.", length);
+	}
+	else {
+		for (int64_t i = r_start; i < r_end; i++) {
+			Value* val = new Value();
+			val->copy(vec->at(i));
+			n_vec->push_back(val);
+		}
+	}
+	
+	CLEVER_RETURN_ARRAY(n_vec);
+}
+
 /**
  * String Array<T>::toString()
  */
@@ -268,6 +318,12 @@ void Array::init() {
 	addMethod((new Method("resize", (MethodPtr)&Array::resize, CLEVER_VOID, false))
 		->addArg("new_size", CLEVER_INT)
 		->addArg("value", CLEVER_TPL_ARG(0))
+	);
+	
+	const Type* arr_t = CLEVER_GET_ARRAY_TEMPLATE->getTemplatedType(CLEVER_TPL_ARG(0));
+	addMethod((new Method("slice", (MethodPtr)&Array::slice, arr_t))
+		->addArg("start", CLEVER_INT)
+		->addArg("length", CLEVER_INT)
 	);
 }
 

--- a/types/array.h
+++ b/types/array.h
@@ -105,6 +105,7 @@ public:
 	static CLEVER_METHOD(at);
 	static CLEVER_METHOD(set);
 	static CLEVER_METHOD(resize);
+	static CLEVER_METHOD(slice);
 	static CLEVER_METHOD(toString);
 	static CLEVER_METHOD(do_assign);
 private:


### PR DESCRIPTION
I made this patch to add slice method to array base type.

We need to improve error messages.

There is an issue!

I don't know how to return a value different of the specified at addMethod... so, when I need to report an error with parameters values, slice method need to return NULL or FALSE... but is returning an empty array...

How can I fix it?

thanks
