### PR TITLE
New setConstruct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (UNIX)
 	execute_process(COMMAND lsb_release -s -i
 		OUTPUT_VARIABLE LSB_RELEASE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-	if (${LSB_RELEASE} MATCHES "Ubuntu")
+	if ((${LSB_RELEASE} MATCHES "Ubuntu") OR (${LSB_RELEASE} MATCHES "LinuxMint"))
 		# Add "-licu" to the end of the linker command line
 		if (MOD_STD_UNICODE)
 			set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} -licuio -licuuc")
@@ -168,7 +168,7 @@ if (UNIX)
 			set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} -lmysqlclient")
 		endif (MOD_DB_MYSQL)
 
-	endif (${LSB_RELEASE} MATCHES "Ubuntu")
+	endif ((${LSB_RELEASE} MATCHES "Ubuntu") OR (${LSB_RELEASE} MATCHES "LinuxMint"))
 
 endif (UNIX)
 

--- a/core/user.h
+++ b/core/user.h
@@ -41,9 +41,7 @@ public:
 	~UserType() {}
 
 	void init(CLEVER_TYPE_INIT_ARGS) {
-		Function* ctor = new Function(getName(), (MethodPtr) &UserType::ctor);
-		setConstructor(ctor);
-		addMethod(ctor);
+		setConstructor((MethodPtr) &UserType::ctor);
 	}
 
 	void setEnvironment(Environment* env) { m_env = env; }

--- a/modules/db/mysql/mysql.cc
+++ b/modules/db/mysql/mysql.cc
@@ -51,11 +51,8 @@ CLEVER_METHOD(Mysql::connect)
 // Type initialization
 CLEVER_TYPE_INIT(Mysql::init)
 {
-	Function* ctor = new Function("Mysql", (MethodPtr) &Mysql::ctor);
+	setConstructor((MethodPtr) &Mysql::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
 	addMethod(new Function("connect",  (MethodPtr) &Mysql::connect));
 }
 

--- a/modules/std/concurrent/condition.cc
+++ b/modules/std/concurrent/condition.cc
@@ -109,11 +109,7 @@ CLEVER_METHOD(Condition::ctor)
 
 CLEVER_TYPE_INIT(Condition::init)
 {
-	Function* ctor = new Function("Condition", (MethodPtr) &Condition::ctor);
-
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &Condition::ctor);
 
 	addMethod(new Function("signal",    (MethodPtr)&Condition::signal));
 	addMethod(new Function("broadcast", (MethodPtr)&Condition::broadcast));

--- a/modules/std/concurrent/mutex.cc
+++ b/modules/std/concurrent/mutex.cc
@@ -92,11 +92,8 @@ CLEVER_METHOD(Mutex::ctor)
 
 CLEVER_TYPE_INIT(Mutex::init)
 {
-	Function* ctor = new Function("Mutex", (MethodPtr) &Mutex::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &Mutex::ctor);
 
 	addMethod(new Function("lock",    (MethodPtr) &Mutex::lock));
 	addMethod(new Function("trylock", (MethodPtr) &Mutex::trylock));

--- a/modules/std/concurrent/thread.cc
+++ b/modules/std/concurrent/thread.cc
@@ -169,11 +169,7 @@ CLEVER_METHOD(Thread::ctor)
 
 CLEVER_TYPE_INIT(Thread::init)
 {
-	Function* ctor = new Function("Thread", (MethodPtr) &Thread::ctor);
-
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &Thread::ctor);
 
 	addMethod(new Function("start",    (MethodPtr)&Thread::start));
 	addMethod(new Function("wait",		(MethodPtr)&Thread::wait));

--- a/modules/std/core/array.cc
+++ b/modules/std/core/array.cc
@@ -298,11 +298,8 @@ CLEVER_METHOD(ArrayType::erase)
 // Type initialization
 CLEVER_TYPE_INIT(ArrayType::init)
 {
-	Function* ctor = new Function("Array", (MethodPtr) &ArrayType::ctor);
+	setConstructor((MethodPtr) &ArrayType::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
 	addMethod(new Function("append",  (MethodPtr) &ArrayType::append));
 	addMethod(new Function("size",    (MethodPtr) &ArrayType::size));
 	addMethod(new Function("at",      (MethodPtr) &ArrayType::at));

--- a/modules/std/core/bool.cc
+++ b/modules/std/core/bool.cc
@@ -32,11 +32,7 @@ CLEVER_METHOD(BoolType::ctor)
 
 CLEVER_TYPE_INIT(BoolType::init)
 {
-	Function* ctor = new Function("Bool", (MethodPtr) &BoolType::ctor);
-
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &BoolType::ctor);
 }
 
 } // clever

--- a/modules/std/core/double.cc
+++ b/modules/std/core/double.cc
@@ -101,11 +101,7 @@ CLEVER_METHOD(DoubleType::ctor)
 
 CLEVER_TYPE_INIT(DoubleType::init)
 {
-	Function* ctor = new Function("Double", (MethodPtr) &DoubleType::ctor);
-
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &DoubleType::ctor);
 }
 
 } // clever

--- a/modules/std/core/function.h
+++ b/modules/std/core/function.h
@@ -156,10 +156,7 @@ public:
 	~FuncType() {}
 
 	void init(CLEVER_TYPE_INIT_ARGS) {
-		Function* ctor = new Function("Function", (MethodPtr) &FuncType::ctor);
-
-		setConstructor(ctor);
-		addMethod(ctor);
+		setConstructor((MethodPtr) &FuncType::ctor);
 	}
 
 	void dump(TypeObject* data, std::ostream& out) const { out << "function() {}"; }

--- a/modules/std/core/int.cc
+++ b/modules/std/core/int.cc
@@ -151,12 +151,9 @@ CLEVER_METHOD(IntType::toString)
 
 CLEVER_TYPE_INIT(IntType::init)
 {
-	Function* ctor = new Function("Int", (MethodPtr) &IntType::ctor);
-
-	setConstructor(ctor);
+	setConstructor((MethodPtr) &IntType::ctor);
 
 	// Methods
-	addMethod(ctor);
 	addMethod(new Function("toString", (MethodPtr) &IntType::toString));
 
 	// Properties

--- a/modules/std/core/map.cc
+++ b/modules/std/core/map.cc
@@ -136,11 +136,8 @@ CLEVER_METHOD(MapType::size)
 
 CLEVER_TYPE_INIT(MapType::init)
 {
-	Function* ctor = new Function("Map", (MethodPtr) &MapType::ctor);
+	setConstructor((MethodPtr) &MapType::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
 	addMethod(new Function("insert", (MethodPtr) &MapType::insert));
 	addMethod(new Function("each",	 (MethodPtr) &MapType::each));
 	addMethod(new Function("size",	 (MethodPtr) &MapType::size));

--- a/modules/std/core/str.cc
+++ b/modules/std/core/str.cc
@@ -345,11 +345,8 @@ CLEVER_METHOD(StrType::split)
 
 CLEVER_TYPE_INIT(StrType::init)
 {
-	Function* ctor = new Function("String", (MethodPtr) &StrType::ctor);
+	setConstructor((MethodPtr) &StrType::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
 	addMethod(new Function("subString",  	(MethodPtr) &StrType::subString));
 	addMethod(new Function("find", 			(MethodPtr) &StrType::find));
 	addMethod(new Function("findFirst", 	(MethodPtr) &StrType::findFirst));

--- a/modules/std/date/date.cc
+++ b/modules/std/date/date.cc
@@ -151,11 +151,8 @@ CLEVER_METHOD(Date::ctor)
 
 CLEVER_TYPE_INIT(Date::init)
 {
-	Function* ctor = new Function("Date", (MethodPtr) &Date::ctor);
+	setConstructor((MethodPtr) &Date::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
 	addMethod(new Function("format",     (MethodPtr) &Date::format));
 	addMethod(new Function("uformat",    (MethodPtr) &Date::uformat));
 	addMethod(new Function("getTime",    (MethodPtr) &Date::getTime));

--- a/modules/std/ffi/ffi.cc
+++ b/modules/std/ffi/ffi.cc
@@ -362,12 +362,10 @@ CLEVER_METHOD(FFI::unload)
 // FFI type initialization
 CLEVER_TYPE_INIT(FFI::init)
 {
-	Function* ctor  = new Function("FFILib", (MethodPtr) &FFI::ctor);
 	Function* fcall = new Function("callThisFunction", (MethodPtr)&FFI::callThisFunction);
 
-	setConstructor(ctor);
+	setConstructor((MethodPtr) &FFI::ctor);
 
-	addMethod(ctor);
 	addMethod(fcall);
 	addMethod(new Function("call",   (MethodPtr)&FFI::call));
 	addMethod(new Function("exec",   (MethodPtr)&FFI::exec))->setStatic();

--- a/modules/std/ffi/ffistruct.cc
+++ b/modules/std/ffi/ffistruct.cc
@@ -161,11 +161,7 @@ CLEVER_METHOD(FFIStruct::setMember)
 
 CLEVER_TYPE_INIT(FFIStruct::init)
 {
-	Function* ctor = new Function("FFIStruct", (MethodPtr) &FFIStruct::ctor);
-
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &FFIStruct::ctor);
 
 	addMethod(new Function("getMember",   (MethodPtr)&FFIStruct::getMember));
 	addMethod(new Function("setMember",   (MethodPtr)&FFIStruct::setMember));
@@ -247,11 +243,7 @@ CLEVER_METHOD(FFITypes::addFunction)
 
 CLEVER_TYPE_INIT(FFITypes::init)
 {
-	Function* ctor = new Function("FFITypes", (MethodPtr) &FFITypes::ctor);
-
-	setConstructor(ctor);
-
-	addMethod(ctor);
+	setConstructor((MethodPtr) &FFITypes::ctor);
 
 	addMethod(new Function("addMember",   (MethodPtr)&FFITypes::addMember));
 	addMethod(new Function("addFunction",   (MethodPtr)&FFITypes::addFunction));

--- a/modules/std/file/cfile.cc
+++ b/modules/std/file/cfile.cc
@@ -158,10 +158,8 @@ CLEVER_METHOD(CFile::isOpen)
 
 CLEVER_TYPE_INIT(CFile::init)
 {
-	Function* ctor = new Function("File", (MethodPtr)&CFile::ctor);
-
-	setConstructor(ctor);
-	addMethod(ctor);
+	setConstructor((MethodPtr)&CFile::ctor);
+	
 	addMethod(new Function("read",		(MethodPtr)&CFile::read));
 	addMethod(new Function("readLine",	(MethodPtr)&CFile::readLine));
 	addMethod(new Function("write",		(MethodPtr)&CFile::write));

--- a/modules/std/reflection/reflect.cc
+++ b/modules/std/reflection/reflect.cc
@@ -352,10 +352,7 @@ CLEVER_METHOD(ReflectType::getProperties)
 // Reflect type initialization
 CLEVER_TYPE_INIT(ReflectType::init)
 {
-	Function* ctor = new Function("Reflect", (MethodPtr) &ReflectType::ctor);
-
-	setConstructor(ctor);
-	addMethod(ctor);
+	setConstructor((MethodPtr) &ReflectType::ctor);
 	addMethod(new Function("getType",    (MethodPtr) &ReflectType::getType));
 
 	// Type checking

--- a/modules/std/regex/pcre.cc
+++ b/modules/std/regex/pcre.cc
@@ -134,11 +134,9 @@ CLEVER_METHOD(Pcre::quote)
 
 CLEVER_TYPE_INIT(Pcre::init)
 {
-	Function* ctor = new Function("Regex", (MethodPtr)&Pcre::constructor);
-
 	// Methods
-	setConstructor(ctor);
-	addMethod(ctor);
+	setConstructor((MethodPtr)&Pcre::constructor);
+
 	addMethod(new Function("matches",    (MethodPtr)&Pcre::matches));
 	addMethod(new Function("group",      (MethodPtr)&Pcre::group));
 	addMethod(new Function("replace",    (MethodPtr)&Pcre::replace));

--- a/modules/std/unicode/string.cc
+++ b/modules/std/unicode/string.cc
@@ -284,11 +284,8 @@ CLEVER_METHOD(UString::replace)
 
 CLEVER_TYPE_INIT(UString::init)
 {
-	Function* ctor = new Function("UString", (MethodPtr) &UString::ctor);
+	setConstructor((MethodPtr) &UString::ctor);
 
-	setConstructor(ctor);
-
-	addMethod(ctor);
 	addMethod(new Function("size",   		(MethodPtr) &UString::size));
 	addMethod(new Function("startsWith",	(MethodPtr) &UString::startsWith));
 	addMethod(new Function("endsWith",		(MethodPtr) &UString::endsWith));

--- a/types/type.cc
+++ b/types/type.cc
@@ -235,4 +235,17 @@ void Type::decrement(Value* value, const VM* vm, CException* exception) const
 	clever_throw("Cannot use -- operator with %s type", getName().c_str());
 }
 
+void Type::setConstructor(MethodPtr method) {
+	Function* func = new Function(getName(), method);
+	m_ctor = func;
+	addMethod(func);
+}
+
+void Type::setDestructor(MethodPtr method) {
+	Function* func = new Function(getName(), method);
+	m_dtor = func;
+	addMethod(func);
+}
+
+
 } // clever

--- a/types/type.h
+++ b/types/type.h
@@ -157,8 +157,9 @@ public:
 	/// Method for retrieve the type name
 	const std::string& getName() const { return m_name; }
 
-	void setConstructor(Function* func) { m_ctor = func; }
-	void setDestructor(Function* func) { m_dtor = func; }
+	void setConstructor(MethodPtr method);
+	
+	void setDestructor(MethodPtr method);
 
 	const Function* getConstructor() const { return m_ctor; }
 	const Function* getDestructor() const { return m_dtor; }


### PR DESCRIPTION
The setConstruct now takes the method as a parameter, avoiding that
the programmer can create a constructor method with a name different
from the module. This avoids the issue where the user can call the
constructor on an already instantiated class and makes it harder to
make mistakes while creating modules for the language.
