### PR TITLE
Fixed std.date test to use UTC

### DIFF
--- a/tests/std.date/date_001.test
+++ b/tests/std.date/date_001.test
@@ -5,9 +5,9 @@ import std.*;
 
 var my_date = date:Date.new(1364710352);
 
-io:println(my_date.format('%Y:%m:%d'));
-io:println(my_date.format('%H:%M:%S'));
+io:println(my_date.uformat('%Y:%m:%d'));
+io:println(my_date.uformat('%H:%M:%S'));
 
 ==RESULT==
 2013:03:31
-03:12:32
+06:12:32


### PR DESCRIPTION
If not fixed, this test will fail on anything else besides GMT-3 systems. Tested on a GMT+1 machine.
